### PR TITLE
Add date pkg

### DIFF
--- a/pkg/date/date.go
+++ b/pkg/date/date.go
@@ -1,0 +1,54 @@
+package date
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrNoLayoutMatched = errors.New("no layout matched")
+)
+
+// EOD returns the end of the day in the provided timezone
+func EOD(t time.Time, loc *time.Location) time.Time {
+	if loc == nil {
+		loc = t.Location()
+	}
+
+	return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, loc)
+}
+
+// BOD returns the beginning of the day in the provided timezone
+func BOD(t time.Time, loc *time.Location) time.Time {
+	if loc == nil {
+		loc = t.Location()
+	}
+
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
+}
+
+// Days returns number of whole days that the duration represents (floored to nearest day)
+func Days(duration time.Duration) int {
+	return int(duration) / int(time.Hour*24)
+}
+
+// WithinDuration tests to see if two time.Time's are within a duration of eachother
+func WithinDuration(expected, actual time.Time, delta time.Duration) bool {
+	dt := expected.Sub(actual)
+
+	return dt > -delta && dt < delta
+}
+
+// ParseAny parses a string into a time.Time according to the first successful layout format
+func ParseAny(layouts []string, dateString string) (time.Time, error) {
+	for _, layout := range layouts {
+		t, err := time.Parse(layout, dateString)
+		if err != nil {
+			continue
+		}
+
+		return t, nil
+	}
+
+	return time.Time{}, ErrNoLayoutMatched
+}

--- a/pkg/date/date_test.go
+++ b/pkg/date/date_test.go
@@ -1,0 +1,113 @@
+package date
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEOD(t *testing.T) {
+	assert := assert.New(t)
+
+	middleOfDay := time.Date(2022, 10, 28, 10, 40, 0, 0, time.UTC)
+	expectedEOD := time.Date(2022, 10, 28, 23, 59, 59, 0, time.UTC)
+
+	actualEOD := EOD(middleOfDay, time.UTC)
+	assert.Equal(expectedEOD, actualEOD)
+}
+
+func TestEOD_with_location(t *testing.T) {
+	assert := assert.New(t)
+
+	inputLoc, err := time.LoadLocation("America/New_York")
+	assert.NoError(err)
+
+	outputLoc, err := time.LoadLocation("America/Chicago")
+	assert.NoError(err)
+
+	middleOfDay := time.Date(2022, 10, 28, 10, 40, 0, 0, inputLoc)
+	expectedEOD := time.Date(2022, 10, 28, 23, 59, 59, 0, outputLoc)
+
+	actualEOD := EOD(middleOfDay, outputLoc)
+	assert.Equal(expectedEOD, actualEOD)
+}
+
+func TestBOD(t *testing.T) {
+	assert := assert.New(t)
+
+	middleOfDay := time.Date(2022, 10, 28, 10, 40, 0, 0, time.UTC)
+	expectedBOD := time.Date(2022, 10, 28, 0, 0, 0, 0, time.UTC)
+
+	actualBOD := BOD(middleOfDay, time.UTC)
+	assert.Equal(expectedBOD, actualBOD)
+}
+
+func TestBOD_with_location(t *testing.T) {
+	assert := assert.New(t)
+
+	inputLoc, err := time.LoadLocation("America/New_York")
+	assert.NoError(err)
+
+	outputLoc, err := time.LoadLocation("America/Chicago")
+	assert.NoError(err)
+
+	middleOfDay := time.Date(2022, 10, 28, 10, 40, 0, 0, inputLoc)
+	expectedBOD := time.Date(2022, 10, 28, 0, 0, 0, 0, outputLoc)
+
+	actualBOD := BOD(middleOfDay, outputLoc)
+	assert.Equal(expectedBOD, actualBOD)
+}
+
+func TestDays(t *testing.T) {
+	assert := assert.New(t)
+
+	duration := time.Duration(24*3*time.Hour) + time.Duration(18*time.Hour)
+
+	days := Days(duration)
+	assert.Equal(3, days)
+}
+
+func TestWithinDuration_dates_within_duration(t *testing.T) {
+	assert := assert.New(t)
+
+	today := time.Now()
+	yesterday := time.Now().Add(-1 * 24 * time.Hour)
+	duration := time.Duration(48 * time.Hour)
+
+	withinDuration := WithinDuration(today, yesterday, duration)
+	assert.True(withinDuration)
+}
+
+func TestWithinDuration_dates_outside_duration(t *testing.T) {
+	assert := assert.New(t)
+
+	today := time.Now()
+	yesterday := time.Now().Add(-1 * 24 * time.Hour)
+	duration := time.Duration(1 * time.Second)
+
+	withinDuration := WithinDuration(today, yesterday, duration)
+	assert.False(withinDuration)
+}
+
+func TestParseAny(t *testing.T) {
+	assert := assert.New(t)
+
+	var approxDateLayouts = []string{"01/02/2006", "01/2006", "2006"}
+	dateString := "10/2022"
+
+	parsedDate, err := ParseAny(approxDateLayouts, dateString)
+	assert.NoError(err)
+
+	assert.Equal(time.Date(2022, 10, 01, 0, 0, 0, 0, time.UTC), parsedDate)
+}
+
+func TestParseAny_error(t *testing.T) {
+	assert := assert.New(t)
+
+	var approxDateLayouts = []string{"01/02/2006", "01/2006", "2006"}
+	dateString := "2022-10-01"
+
+	_, err := ParseAny(approxDateLayouts, dateString)
+	assert.ErrorIs(err, ErrNoLayoutMatched)
+}


### PR DESCRIPTION
I found myself needing the `BOD` function for comms (PC-459) so this extracts the `date` package from hub-server for use in hub-server, comms, and any other repos that may need it.

Also added unit tests.