### PR TITLE
Adds support for auto updated time.Time field to bao via tag `auto_updated_at`

### DIFF
--- a/pkg/bao/bao.go
+++ b/pkg/bao/bao.go
@@ -425,7 +425,7 @@ func autoUpdatedAt[ModelT any](ctx context.Context, bun bun.IDB, model *ModelT) 
 
 		switch autoUpdateFieldValue.Interface().(type) {
 		case time.Time:
-			autoUpdateFieldValue.Set(reflect.ValueOf(time.Now()))
+			autoUpdateFieldValue.Set(reflect.ValueOf(time.Now().UTC()))
 		default:
 			// TODO: log about not setting auto_updated_at tag on non time.Time struct fields
 			continue

--- a/pkg/bao/bao.go
+++ b/pkg/bao/bao.go
@@ -159,9 +159,12 @@ func Create[ModelT any](ctx context.Context, db bun.IDB, model *ModelT, befores 
 			}
 		}
 
-		autoUpdatedAt(ctx, tx, model)
+		err := autoUpdatedAt(ctx, tx, model)
+		if err != nil {
+			return errs.Wrap(err, "auto updated at")
+		}
 
-		_, err := tx.NewInsert().Model(model).Exec(ctx)
+		_, err = tx.NewInsert().Model(model).Exec(ctx)
 		if err != nil {
 			return errs.Wrap(err, "inserting model")
 		}
@@ -207,7 +210,10 @@ func Update[ModelT any](ctx context.Context, db bun.IDB, model *ModelT, befores 
 			}
 		}
 
-		autoUpdatedAt(ctx, tx, model)
+		err = autoUpdatedAt(ctx, tx, model)
+		if err != nil {
+			return errs.Wrap(err, "auto updated at")
+		}
 
 		_, err = tx.NewUpdate().Model(model).WherePK().Exec(ctx)
 		if err != nil {


### PR DESCRIPTION
This PR would open the door to automatically updating time.Time fields on models.
i.e.

```go
type userModel struct {
	ID        string    `bun:",pk"`
	UpdatedAt time.Time `bao:",auto_updated_at"`
}
```
userModel.UpdatedAt would be controlled by `bao`

The main issue is that this will not work for relational fields
i.e.

```go
type userModel struct {
	ID        string          `bun:",pk"`
	UpdatedAt time.Time       `bao:",auto_updated_at"`
	Accounts  []*accountModel `bun:",rel:has-many" bao:",persist"`
}

type accountModel struct {
	ID        string    `bun:",pk"`
	UpdatedAt time.Time `bao:",auto_updated_at"` // This field would not be controlled by bao
}
```

we can likely make it work with adjustments to the way that `relatedModels` processes relations