### PR TITLE
PC-1245 GetString function

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -11,10 +11,10 @@ const (
 	EnvProd  string = "prod"
 )
 
-func Get[T bool | []byte | int | string](key string, d T) T {
+func Get[T bool | []byte | int | string](key string, defaultVal T) T {
 	v, exists := os.LookupEnv(key)
 	if !exists {
-		return d
+		return defaultVal
 	}
 
 	var ret T
@@ -22,7 +22,7 @@ func Get[T bool | []byte | int | string](key string, d T) T {
 	case *bool:
 		b, err := strconv.ParseBool(v)
 		if err != nil {
-			return d
+			return defaultVal
 		}
 
 		*ptr = b
@@ -33,7 +33,7 @@ func Get[T bool | []byte | int | string](key string, d T) T {
 	case *int:
 		i, err := strconv.Atoi(v)
 		if err != nil {
-			return d
+			return defaultVal
 		}
 
 		*ptr = i
@@ -54,6 +54,17 @@ func GetExists[T bool | []byte | int | string](key string) (T, bool) {
 	}
 
 	return Get(key, v), true
+}
+
+// Different from Get[string] in that it returns the default value if the
+// environment variable exists but is empty.
+func GetString(key, defaultVal string) string {
+	val := Get[string](key, defaultVal)
+	if val == "" {
+		return defaultVal
+	}
+
+	return val
 }
 
 func IsLocal() bool {

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -11,10 +11,12 @@ func TestGet(t *testing.T) {
 	assert := assert.New(t)
 
 	os.Setenv("FOO", "1")
+	os.Setenv("BAR", "")
 	assert.Equal("1", Get("FOO", ""))
 	assert.Equal([]byte("1"), Get("FOO", []byte("")))
 	assert.Equal(1, Get("FOO", 0))
 	assert.Equal(true, Get("FOO", false))
+	assert.Equal("", Get("BAR", "default"))
 }
 
 func TestGet_default(t *testing.T) {
@@ -38,6 +40,22 @@ func TestGetExists(t *testing.T) {
 	v, exists = GetExists[string]("BAR")
 	assert.Equal("", v)
 	assert.False(exists)
+}
+
+func TestGetString(t *testing.T) {
+	assert := assert.New(t)
+
+	os.Setenv("FOO", "1")
+	os.Setenv("BAR", "")
+
+	v := GetString("FOO", "default1")
+	assert.Equal("1", v)
+
+	v = Get("FOO", "default1")
+	assert.Equal("1", v)
+
+	v = GetString("BAR", "default2")
+	assert.Equal("default2", v)
 }
 
 func TestIsLocal(t *testing.T) {


### PR DESCRIPTION
- better names for some parameters
- Adds GetString, which will return default if env is set, but empty
- tests to confirm current Get behavior is value is set but empty
- test for GetString