### PR TITLE
chore: bump go to 1.26.5

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -24,7 +24,7 @@ jobs:
           go-version: "^1.26"
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@v9.3.0
 
         with:
           version: latest

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.26.4
+golang 1.26.5
 oxfmt latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine
+FROM golang:1.26.5-alpine
 
 RUN apk upgrade --no-cache && \
     apk --no-cache add libc-dev gcc bash git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eleanorhealth/go-common/v2
 
-go 1.26.4
+go 1.26.5
 
 tool (
 	github.com/golangci/golangci-lint/cmd/golangci-lint


### PR DESCRIPTION
Bumps the Go toolchain from 1.26.4 to 1.26.5.

- go.mod: `go 1.26.4` -> `go 1.26.5`
- Dockerfile: `FROM golang:1.26-alpine` -> `FROM golang:1.26.5-alpine` (pinned to exact patch to match the rest of the fleet)
- .tool-versions: `golang 1.26.4` -> `golang 1.26.5`
- .github/workflows/golangci-lint.yaml: bumped `golangci/golangci-lint-action` from v9.2.0 to v9.3.0 (issues were seen running earlier golangci-lint-action versions against the latest Go)

`go build ./...` verified locally with go1.26.5.